### PR TITLE
Fix light mode home link color contrast

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -45,6 +45,7 @@
   --color-text-soft: color-mix(in oklch, var(--color-text) 55%, transparent);
   --color-link: #1d4ed8;
   --color-link-hover: #1e40af;
+  --color-home-link: #0070f3;
   --color-toc-active: #0070f3;
   --color-accent: #2563eb;
   --color-accent-soft: #dbeafe;
@@ -95,6 +96,7 @@
     --color-text-soft: color-mix(in oklch, var(--color-text) 45%, transparent);
     --color-link: #93c5fd;
     --color-link-hover: #bfdbfe;
+    --color-home-link: #47a8ff;
     --color-toc-active: #3291ff;
     --color-accent: #60a5fa;
     --color-accent-soft: oklch(0.269 0.06 264);
@@ -138,6 +140,7 @@
   --color-text-soft: color-mix(in oklch, var(--color-text) 45%, transparent);
   --color-link: #93c5fd;
   --color-link-hover: #bfdbfe;
+  --color-home-link: #47a8ff;
   --color-toc-active: #3291ff;
   --color-accent: #60a5fa;
   --color-accent-soft: oklch(0.269 0.06 264);
@@ -470,7 +473,7 @@ a:not(
 
 a.home-inline-link,
 a.home-writings-link {
-  color: #47a8ff !important;
+  color: var(--color-home-link) !important;
   font-weight: 500;
   text-decoration-line: none !important;
   text-decoration-thickness: 0.1em;
@@ -482,9 +485,9 @@ a.home-writings-link {
 
 a.home-inline-link:hover,
 a.home-writings-link:hover {
-  color: #47a8ff !important;
+  color: var(--color-home-link) !important;
   text-decoration-line: underline !important;
-  text-decoration-color: #47a8ff !important;
+  text-decoration-color: var(--color-home-link) !important;
 }
 
 .home-footer {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #15. The merged PR included landing page copy and link hover behavior, but the theme-aware link color fix was left out.

## Changes

- Light mode home links: `#0070f3` (stronger contrast on white)
- Dark mode home links: `#47a8ff` (Vercel-style blue on dark bg)
- Uses `--color-home-link` token so inline + writings links pick up the right color per theme
- Hover behavior unchanged: underline appears on hover only

## Testing

- `npm run build` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6124b5b6-de9b-4269-952d-8ba1ebb2b774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6124b5b6-de9b-4269-952d-8ba1ebb2b774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

