### PR TITLE
Add Paytm Insider ticketing queue to tech contributions

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -142,6 +142,16 @@ export default async function HomePage() {
             </LinkPreviewServer>{" "}
             in Go, 1M+ daily API requests
           </li>
+          <li>
+            Ticketing queue in Go for Paytm{" "}
+            <LinkPreviewServer
+              href="https://insider.in/"
+              className="home-inline-link"
+            >
+              Insider
+            </LinkPreviewServer>
+            , 40,000+ concurrent requests
+          </li>
           <li>IAM service in Go serving 100K+ users daily</li>
           <li>
             Network infrastructure for{" "}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -150,7 +150,7 @@ export default async function HomePage() {
             >
               Insider
             </LinkPreviewServer>
-            , 40,000+ concurrent requests
+            , 40,000+ concurrent requests at sub-200ms p99
           </li>
           <li>IAM service in Go serving 100K+ users daily</li>
           <li>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the Paytm Insider ticketing queue contribution to the landing page tech contributions list.

**Change**
- New bullet under "Some of my tech contributions:" for the Go ticketing queue built for [Insider](https://insider.in/), handling 40,000+ concurrent requests
- Placed after the custom reverse proxy item and before the IAM service item
- Uses the existing `LinkPreviewServer` pattern for the Insider link
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a3215dc-a069-4541-86ce-ca8de08c777b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a3215dc-a069-4541-86ce-ca8de08c777b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

