### PR TITLE
Fix views API 500: drop Bun runtime on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,3 @@
 {
-    "$schema": "https://openapi.vercel.sh/vercel.json",
-    "bunVersion": "1.x"
-  }
+  "$schema": "https://openapi.vercel.sh/vercel.json"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Prod `/api/views` returns 500 after Next 16.3 deploy
- Error: Bun fails loading `next/dist/compiled/next-server/app-page-turbo.runtime.prod.js` with `Expected CommonJS module to have a function wrapper`
- Cause: `vercel.json` had `bunVersion: "1.x"` → Vercel ran Next on Bun; Next 16.3 Turbopack prod runtime is incompatible with Bun's CJS loader ([bun#21137](https://github.com/oven-sh/bun/issues/21137), [next#87417](https://github.com/vercel/next.js/issues/87417))
- Fix: remove `bunVersion` so Vercel uses Node runtime (local `bun` for install/dev unchanged)

## Test plan
- [x] Confirmed prod `GET/POST https://www.raghu.app/api/views?slug=/writings/simd` → 500
- [ ] After deploy: same endpoint returns `{ "views": N }` (200)
- [ ] Writing pages show view counts again

Note: Vercel MCP auth unavailable in this cloud agent session — used pasted runtime error + live 500 repro instead of plugin logs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-299de75e-d405-4117-a6ea-a1a404a777a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-299de75e-d405-4117-a6ea-a1a404a777a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

